### PR TITLE
Add Notepad app

### DIFF
--- a/public/images/apps/notepad.svg
+++ b/public/images/apps/notepad.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="8" y="8" width="48" height="48" rx="6" ry="6" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="20" x2="48" y2="20" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="28" x2="48" y2="28" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="36" x2="48" y2="36" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="44" x2="48" y2="44" stroke="#000" stroke-width="2"/>
+</svg>

--- a/src/Pages/main.js
+++ b/src/Pages/main.js
@@ -6,6 +6,7 @@ import StartMenu from "../components/layout/StartMenu";
 import Browser from "../components/apps/Browser";
 import Calculator from "../components/apps/Calculator";
 import VsCode from "../components/apps/VsCode";
+import Notepad from "../components/apps/Notepad";
 import Slider from "../components/utilities/Slider";
 import RecycleBin from "../components/apps/RecycleBin";
 import Apps from "../components/apps/Apps";
@@ -29,6 +30,7 @@ function Main() {
     vscode: false,
     recycle: false,
     app: false,
+    notepad: false,
   });
 
   const [aboutMe, setAboutMe] = useState(null);
@@ -40,12 +42,13 @@ function Main() {
       start: false,
       explorer: false,
       browser: false,
-      calculator: false,
-      vscode: false,
-      recycle: false,
-      app: false,
-      [window]: !windows[window],
-    });
+    calculator: false,
+    vscode: false,
+    recycle: false,
+    app: false,
+    notepad: false,
+    [window]: !windows[window],
+  });
 
     if (window === "explorer" && input !== null) {
       setAboutMe(input);
@@ -208,6 +211,11 @@ function Main() {
           <VsCode
             isAppOpen={windows.vscode}
             toggleVsCode={() => toggleWindow("vscode")}
+            bounds={bounds}
+          />
+          <Notepad
+            isAppOpen={windows.notepad}
+            toggleNotepad={() => toggleWindow("notepad")}
             bounds={bounds}
           />
           <Apps

--- a/src/components/apps/Notepad.jsx
+++ b/src/components/apps/Notepad.jsx
@@ -1,0 +1,42 @@
+import React, { useRef } from "react";
+import Draggable from "react-draggable";
+
+const Notepad = ({ isAppOpen, toggleNotepad, bounds }) => {
+  const notepadRef = useRef(null);
+  return (
+    <div className={`${isAppOpen ? "" : "hidden"} z-30 w-full h-screen pointer-events-none absolute`}>
+      <Draggable handle=".title-bar" nodeRef={notepadRef} bounds={bounds}>
+        <div
+          ref={notepadRef}
+          className="window bg-white text-black h-[30rem] w-[40rem] rounded-xl overflow-hidden border-neutral-700 border-[1.5px] pointer-events-auto"
+        >
+          <div className="title-bar">
+            <div className="h-9 flex justify-between select-none">
+              <div className="m-1 ml-4 font-normal">Notepad</div>
+              <div className="flex">
+                <div
+                  className="material-symbols-outlined hover:bg-neutral-200 mb-2 w-11 flex justify-center items-center text-xl"
+                  onClick={toggleNotepad}
+                >
+                  minimize
+                </div>
+                <div className="material-symbols-outlined hover:bg-neutral-200 mb-2 w-11 flex justify-center items-center text-sm">
+                  check_box_outline_blank
+                </div>
+                <div
+                  className="material-symbols-outlined hover:bg-red-500 mb-2 w-12 flex justify-center items-center text-xl"
+                  onClick={toggleNotepad}
+                >
+                  close
+                </div>
+              </div>
+            </div>
+          </div>
+          <textarea className="w-full h-full p-2 outline-none resize-none bg-white text-black" />
+        </div>
+      </Draggable>
+    </div>
+  );
+};
+
+export default Notepad;

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -310,6 +310,13 @@ const appsData = [
     subAction: "spotify",
     size: "w-10 h-10",
   },
+  {
+    id: 9,
+    name: "Notepad",
+    icon: "/images/apps/notepad.svg",
+    action: "notepad",
+    size: "w-10 h-10",
+  },
 ];
 
 // Export default data


### PR DESCRIPTION
## Summary
- add simple draggable Notepad app
- register Notepad window in main page state management
- list Notepad in apps data
- include a minimal SVG icon

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ca39e3c64832c89953a50c30e187e